### PR TITLE
Upgrade to SDK 1.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-m2-{{ checksum "pom.xml" }}
-            - m2
       - install_sdk
       - run:
           name: Build Application

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   application:
     docker:
       - image: digitalasset/daml-sdk:1.2.0
-      - user: root
+        user: root
     environment:
       MAVEN_OPTS: -Xmx3200m
     steps:
@@ -38,7 +38,7 @@ jobs:
   daml:
     docker:
       - image: digitalasset/daml-sdk:1.2.0
-      - user: root
+        user: root
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           name: Build Application
           command: |
             apk add make maven
+            su daml
             make build-app
       - run:
           name: Test Application
@@ -46,6 +47,7 @@ jobs:
           name: Test Dar
           command: |
             apk add make
+            su daml
             make test-dar
       - run:
           name: Build Dar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
   application:
     docker:
       - image: digitalasset/daml-sdk:1.2.0
+      - user: root
     environment:
       MAVEN_OPTS: -Xmx3200m
     steps:
@@ -17,7 +18,7 @@ jobs:
       - run:
           name: Build Application
           command: |
-            su -c "apk add make maven"
+            apk add make maven
             make build-app
       - run:
           name: Test Application
@@ -37,13 +38,14 @@ jobs:
   daml:
     docker:
       - image: digitalasset/daml-sdk:1.2.0
+      - user: root
     steps:
       - checkout
       - setup_remote_docker
       - run:
           name: Test Dar
           command: |
-            su -c "apk add make"
+            apk add make
             make test-dar
       - run:
           name: Build Dar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,17 @@
 # SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 version: 2.1
 
+commands:
+  install_sdk:
+    description: "Install the DAML SDK"
+    steps:
+      - run:
+          command: curl https://get.daml.com | sh -s 1.2.0
+
 jobs:
   application:
     docker:
-      - image: digitalasset/daml-sdk:1.2.0
-        user: root
+      - image: circleci/openjdk:11.0-jdk
     environment:
       MAVEN_OPTS: -Xmx3200m
     steps:
@@ -15,11 +21,11 @@ jobs:
           keys:
             - m2-{{ checksum "pom.xml" }}
             - m2
+      - install_sdk
       - run:
           name: Build Application
           command: |
-            apk add make maven
-            su daml -s /bin/bash -c "make build-app"
+            make build-app
       - run:
           name: Test Application
           command: make test-app
@@ -37,25 +43,24 @@ jobs:
           path: ~/test-results
   daml:
     docker:
-      - image: digitalasset/daml-sdk:1.2.0
-        user: root
+      - image: circleci/openjdk:11.0-jdk
     steps:
       - checkout
       - setup_remote_docker
+      - install_sdk
       - run:
           name: Test Dar
           command: |
-            apk add make maven
-            su daml -s /bin/bash -c "make test-dar"
+            make test-dar
       - run:
           name: Build Dar
           command:  |
-            su daml -s /bin/bash -c "make build-dar"
+            make build-dar
       - run:
           name: Save test results
           command: |
-            su daml -s /bin/bash -c "mkdir -pv ~/test-results/daml"
-            su daml -s ibin/bash -c "find . -type f -regex ".*/target/.*DarTests.xml" -exec cp {} ~/test-results/daml/ \;"
+            mkdir -pv ~/test-results/daml
+            find . -type f -regex ".*/target/.*DarTests.xml" -exec cp {} ~/test-results/daml/ \;
       - store_test_results:
           path: ~/test-results
   integration-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   application:
     docker:
-      - image: digitalasset/daml-sdk:0.13.10
+      - image: digitalasset/daml-sdk:1.2.0
     environment:
       MAVEN_OPTS: -Xmx3200m
     steps:
@@ -36,7 +36,7 @@ jobs:
           path: ~/test-results
   daml:
     docker:
-      - image: digitalasset/daml-sdk:0.13.10
+      - image: digitalasset/daml-sdk:1.2.0
     steps:
       - checkout
       - setup_remote_docker
@@ -58,7 +58,7 @@ jobs:
           path: ~/test-results
   integration-test:
     docker:
-      - image: digitalasset/daml-sdk:0.13.10
+      - image: digitalasset/daml-sdk:1.2.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,7 @@ jobs:
           name: Build Application
           command: |
             apk add make maven
-            su - daml -s /bin/bash
-            make build-app
+            su daml -s /bin/bash -c "make build-app"
       - run:
           name: Test Application
           command: make test-app
@@ -47,16 +46,16 @@ jobs:
           name: Test Dar
           command: |
             apk add make maven
-            su - daml -s /bin/bash -c "make test-dar"
+            su daml -s /bin/bash -c "make test-dar"
       - run:
           name: Build Dar
           command:  |
-            su - daml -s /bin/bash -c "make build-dar"
+            su daml -s /bin/bash -c "make build-dar"
       - run:
           name: Save test results
           command: |
-            su - daml -s /bin/bash -c "mkdir -pv ~/test-results/daml"
-            su - daml -s ibin/bash -c "find . -type f -regex ".*/target/.*DarTests.xml" -exec cp {} ~/test-results/daml/ \;"
+            su daml -s /bin/bash -c "mkdir -pv ~/test-results/daml"
+            su daml -s ibin/bash -c "find . -type f -regex ".*/target/.*DarTests.xml" -exec cp {} ~/test-results/daml/ \;"
       - store_test_results:
           path: ~/test-results
   integration-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Test Dar
           command: |
-            apk add make
+            sudo apk add make
             make test-dar
       - run:
           name: Build Dar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,18 +46,17 @@ jobs:
       - run:
           name: Test Dar
           command: |
-            apk add make
-            su - daml -s /bin/bash
-            make test-dar
+            apk add make maven
+            su - daml -s /bin/bash -c "make test-dar"
       - run:
           name: Build Dar
           command:  |
-            make build-dar
+            su - daml -s /bin/bash -c "make build-dar"
       - run:
           name: Save test results
           command: |
-            mkdir -pv ~/test-results/daml
-            find . -type f -regex ".*/target/.*DarTests.xml" -exec cp {} ~/test-results/daml/ \;
+            su - daml -s /bin/bash -c "mkdir -pv ~/test-results/daml"
+            su - daml -s ibin/bash -c "find . -type f -regex ".*/target/.*DarTests.xml" -exec cp {} ~/test-results/daml/ \;"
       - store_test_results:
           path: ~/test-results
   integration-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           keys:
             - m2-{{ checksum "pom.xml" }}
             - m2
+            - abc
       - install_sdk
       - run:
           name: Build Application

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Build Application
           command: |
             apk add make maven
-            su daml
+            cat /etc/passwd
             make build-app
       - run:
           name: Test Application
@@ -47,7 +47,7 @@ jobs:
           name: Test Dar
           command: |
             apk add make
-            su daml
+            cat /etc/passwd
             make test-dar
       - run:
           name: Build Dar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Build Application
           command: |
             apk add make maven
-            cat /etc/passwd
+            su - daml -s /bin/bash
             make build-app
       - run:
           name: Test Application
@@ -47,7 +47,7 @@ jobs:
           name: Test Dar
           command: |
             apk add make
-            cat /etc/passwd
+            su - daml -s /bin/bash
             make test-dar
       - run:
           name: Build Dar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Build Application
           command: |
-            apk add make maven
+            su -c "apk add make maven"
             make build-app
       - run:
           name: Test Application
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Test Dar
           command: |
-            sudo apk add make
+            su -c "apk add make"
             make test-dar
       - run:
           name: Build Dar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - m2-{{ checksum "pom.xml" }}
+            - v1-m2-{{ checksum "pom.xml" }}
             - m2
-            - abc
       - install_sdk
       - run:
           name: Build Application
@@ -33,7 +32,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-          key: m2-{{ checksum "pom.xml" }}
+          key: v1-m2-{{ checksum "pom.xml" }}
       - run:
           name: Save test results
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ pom.xml.tag
 pom.xml.versionsBackup
 release.properties
 sqlite/
+.daml/
+/target/

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 0.13.10
+sdk-version: 1.2.0
 name: ex-bond-trading
 source: src/main/daml/BondTradingMain.daml
 parties:

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.daml.ledger</groupId>
+            <groupId>com.daml</groupId>
             <artifactId>bindings-java</artifactId>
-            <version>100.13.10</version>
+            <version>1.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
@@ -23,14 +23,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.digitalasset</groupId>
-            <artifactId>daml-lf-archive</artifactId>
-            <version>100.13.10</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.8.0</version>
+            <version>3.11.0</version>
         </dependency>
         <dependency>
             <groupId>args4j</groupId>

--- a/scripts/start
+++ b/scripts/start
@@ -10,4 +10,4 @@ BASE=$(dirname $0)/..
 VERSION=1.0
 
 cd $BASE
-daml start --open-browser no --on-start "scripts/startApp" --wait-for-signal no
+daml start --open-browser no --json-api-port none --on-start "scripts/startApp" --wait-for-signal no

--- a/scripts/startApp
+++ b/scripts/startApp
@@ -18,18 +18,20 @@ export LINES=$(tput lines)
 
 APP_PIDS=""
 
+MAIN_PACKAGE_ID=$(daml damlc inspect-dar .daml/dist/ex-bond-trading-3.0.0.dar --json | jq .main_package_id -r)
+
 CSI="\033["
 viewport=$(($(tput lines) - 2))
 cmd=$((viewport + 1))
 status=$((cmd + 1))
 
 runApp () {
-  java -jar $APP_JAR --port 6865 $@ &
+  java -jar $APP_JAR --main-package-id $MAIN_PACKAGE_ID --port 6865 $@ &
   APP_PIDS="$APP_PIDS $!"
 }
 
 runBackground() {
-  java -jar $APP_JAR --port 6865 $@ &
+  java -jar $APP_JAR --main-package-id $MAIN_PACKAGE_ID --port 6865 $@ &
   APP_PIDS="$APP_PIDS $!"
 }
 

--- a/src/main/java/com/digitalasset/examples/bondTrading/processor/EventProcessor.java
+++ b/src/main/java/com/digitalasset/examples/bondTrading/processor/EventProcessor.java
@@ -4,28 +4,28 @@
 package com.digitalasset.examples.bondTrading.processor;
 
 import com.digitalasset.examples.bondTrading.BondTradingMain;
-import com.digitalasset.ledger.api.v1.CommandCompletionServiceGrpc;
-import com.digitalasset.ledger.api.v1.CommandCompletionServiceOuterClass;
-import com.digitalasset.ledger.api.v1.CommandSubmissionServiceGrpc;
-import com.digitalasset.ledger.api.v1.CommandSubmissionServiceOuterClass.SubmitRequest;
-import com.digitalasset.ledger.api.v1.CompletionOuterClass;
-import com.digitalasset.ledger.api.v1.CompletionOuterClass.Completion;
-import com.digitalasset.ledger.api.v1.CommandsOuterClass;
-import com.digitalasset.ledger.api.v1.CommandsOuterClass.Command;
-import com.digitalasset.ledger.api.v1.CommandsOuterClass.CreateCommand;
-import com.digitalasset.ledger.api.v1.CommandsOuterClass.ExerciseCommand;
-import com.digitalasset.ledger.api.v1.EventOuterClass;
-import com.digitalasset.ledger.api.v1.EventOuterClass.Event;
-import com.digitalasset.ledger.api.v1.EventOuterClass.CreatedEvent;
-import com.digitalasset.ledger.api.v1.LedgerOffsetOuterClass;
-import com.digitalasset.ledger.api.v1.TransactionFilterOuterClass;
-import com.digitalasset.ledger.api.v1.TransactionOuterClass.Transaction;
-import com.digitalasset.ledger.api.v1.TransactionServiceGrpc;
-import com.digitalasset.ledger.api.v1.TransactionServiceOuterClass;
-import com.digitalasset.ledger.api.v1.ValueOuterClass;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Identifier;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Record;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Value;
+import com.daml.ledger.api.v1.CommandCompletionServiceGrpc;
+import com.daml.ledger.api.v1.CommandCompletionServiceOuterClass;
+import com.daml.ledger.api.v1.CommandSubmissionServiceGrpc;
+import com.daml.ledger.api.v1.CommandSubmissionServiceOuterClass.SubmitRequest;
+import com.daml.ledger.api.v1.CompletionOuterClass;
+import com.daml.ledger.api.v1.CompletionOuterClass.Completion;
+import com.daml.ledger.api.v1.CommandsOuterClass;
+import com.daml.ledger.api.v1.CommandsOuterClass.Command;
+import com.daml.ledger.api.v1.CommandsOuterClass.CreateCommand;
+import com.daml.ledger.api.v1.CommandsOuterClass.ExerciseCommand;
+import com.daml.ledger.api.v1.EventOuterClass;
+import com.daml.ledger.api.v1.EventOuterClass.Event;
+import com.daml.ledger.api.v1.EventOuterClass.CreatedEvent;
+import com.daml.ledger.api.v1.LedgerOffsetOuterClass;
+import com.daml.ledger.api.v1.TransactionFilterOuterClass;
+import com.daml.ledger.api.v1.TransactionOuterClass.Transaction;
+import com.daml.ledger.api.v1.TransactionServiceGrpc;
+import com.daml.ledger.api.v1.TransactionServiceOuterClass;
+import com.daml.ledger.api.v1.ValueOuterClass;
+import com.daml.ledger.api.v1.ValueOuterClass.Identifier;
+import com.daml.ledger.api.v1.ValueOuterClass.Record;
+import com.daml.ledger.api.v1.ValueOuterClass.Value;
 
 
 import com.google.protobuf.Empty;
@@ -276,12 +276,9 @@ abstract class EventProcessor {
             commands.forEach(cmd -> log.debug("{} sending command {}, commandId={}", party, cmdDescription(cmd), commandId));
             log.info("{} submits commands, commandId={}, workflowId={}", party, commandId, workFlowId);
 
-            long ledgerEffTimeSecs = (useWallTime ? System.currentTimeMillis() : Instant.EPOCH.toEpochMilli()) / 1000 ;
             SubmitRequest request = SubmitRequest.newBuilder()
                 .setCommands(CommandsOuterClass.Commands.newBuilder()
                     .setCommandId(commandId)
-                    .setLedgerEffectiveTime(Timestamp.newBuilder().setSeconds(ledgerEffTimeSecs))
-                    .setMaximumRecordTime(Timestamp.newBuilder().setSeconds(ledgerEffTimeSecs+10L))
                     .setWorkflowId(workFlowId)
                     .setLedgerId(ledgerId)
                     .setParty(party)

--- a/src/main/java/com/digitalasset/examples/bondTrading/processor/MarketSetupProcessor.java
+++ b/src/main/java/com/digitalasset/examples/bondTrading/processor/MarketSetupProcessor.java
@@ -6,14 +6,14 @@ package com.digitalasset.examples.bondTrading.processor;
 import io.grpc.ManagedChannel;
 
 import com.digitalasset.examples.bondTrading.BondTradingMain;
-import com.digitalasset.ledger.api.v1.CommandsOuterClass.Command;
-import com.digitalasset.ledger.api.v1.CompletionOuterClass;
-import com.digitalasset.ledger.api.v1.EventOuterClass;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Identifier;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Record;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.List;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.RecordField;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Value;
+import com.daml.ledger.api.v1.CommandsOuterClass.Command;
+import com.daml.ledger.api.v1.CompletionOuterClass;
+import com.daml.ledger.api.v1.EventOuterClass;
+import com.daml.ledger.api.v1.ValueOuterClass.Identifier;
+import com.daml.ledger.api.v1.ValueOuterClass.Record;
+import com.daml.ledger.api.v1.ValueOuterClass.List;
+import com.daml.ledger.api.v1.ValueOuterClass.RecordField;
+import com.daml.ledger.api.v1.ValueOuterClass.Value;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -229,7 +229,7 @@ public class MarketSetupProcessor extends EventProcessor {
                     .setValue(Value.newBuilder().setText(isin)))
                 .addFields(RecordField.newBuilder()
                     .setLabel("amount")
-                    .setValue(Value.newBuilder().setDecimal(amount))));
+                    .setValue(Value.newBuilder().setNumeric(amount))));
     }
 
     private Value.Builder cashEntry(String currency, String amount) {
@@ -248,7 +248,7 @@ public class MarketSetupProcessor extends EventProcessor {
                     .setValue(Value.newBuilder().setText(currency)))
                 .addFields(RecordField.newBuilder()
                     .setLabel("amount")
-                    .setValue(Value.newBuilder().setDecimal(amount))));
+                    .setValue(Value.newBuilder().setNumeric(amount))));
     }
 
 

--- a/src/main/java/com/digitalasset/examples/bondTrading/processor/TradeInjector.java
+++ b/src/main/java/com/digitalasset/examples/bondTrading/processor/TradeInjector.java
@@ -4,13 +4,13 @@
 package com.digitalasset.examples.bondTrading.processor;
 
 import com.digitalasset.examples.bondTrading.BondTradingMain;
-import com.digitalasset.ledger.api.v1.CommandsOuterClass.Command;
-import com.digitalasset.ledger.api.v1.CompletionOuterClass;
-import com.digitalasset.ledger.api.v1.EventOuterClass;
-import com.digitalasset.ledger.api.v1.ValueOuterClass;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Record;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.RecordField;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Value;
+import com.daml.ledger.api.v1.CommandsOuterClass.Command;
+import com.daml.ledger.api.v1.CompletionOuterClass;
+import com.daml.ledger.api.v1.EventOuterClass;
+import com.daml.ledger.api.v1.ValueOuterClass;
+import com.daml.ledger.api.v1.ValueOuterClass.Record;
+import com.daml.ledger.api.v1.ValueOuterClass.RecordField;
+import com.daml.ledger.api.v1.ValueOuterClass.Value;
 
 
 import io.grpc.ManagedChannel;
@@ -148,7 +148,7 @@ public class TradeInjector extends EventProcessor {
                 .setValue(ValueOuterClass.Value.newBuilder().setText(record.get("bondIsin"))))
             .addFields(ValueOuterClass.RecordField.newBuilder()
                 .setLabel("bondAmount")
-                .setValue(ValueOuterClass.Value.newBuilder().setDecimal(record.get("bondAmount"))))
+                .setValue(ValueOuterClass.Value.newBuilder().setNumeric(record.get("bondAmount"))))
             .addFields(ValueOuterClass.RecordField.newBuilder()
                 .setLabel("cashIssuer")
                 .setValue(ValueOuterClass.Value.newBuilder().setParty(record.get("cashIssuer"))))
@@ -157,7 +157,7 @@ public class TradeInjector extends EventProcessor {
                 .setValue(ValueOuterClass.Value.newBuilder().setText(record.get("cashCurrency"))))
             .addFields(ValueOuterClass.RecordField.newBuilder()
                 .setLabel("cashAmount")
-                .setValue(ValueOuterClass.Value.newBuilder().setDecimal(record.get("cashAmount"))))
+                .setValue(ValueOuterClass.Value.newBuilder().setNumeric(record.get("cashAmount"))))
             .addFields(ValueOuterClass.RecordField.newBuilder()
                 .setLabel("settleTime")
                 .setValue(ValueOuterClass.Value.newBuilder().setTimestamp(settlementTime)))

--- a/src/main/java/com/digitalasset/examples/bondTrading/processor/TradingPartyProcessor.java
+++ b/src/main/java/com/digitalasset/examples/bondTrading/processor/TradingPartyProcessor.java
@@ -4,16 +4,15 @@
 package com.digitalasset.examples.bondTrading.processor;
 
 import com.digitalasset.examples.bondTrading.BondTradingMain;
-import com.digitalasset.ledger.api.v1.CommandsOuterClass.Command;
-import com.digitalasset.ledger.api.v1.EventOuterClass.CreatedEvent;
-import com.digitalasset.ledger.api.v1.EventOuterClass.ArchivedEvent;
-import com.digitalasset.ledger.api.v1.EventOuterClass.ExercisedEvent;
-import com.digitalasset.ledger.api.v1.ValueOuterClass;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Value;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.Record;
-import com.digitalasset.ledger.api.v1.ValueOuterClass.RecordField;
+import com.daml.ledger.api.v1.CommandsOuterClass.Command;
+import com.daml.ledger.api.v1.EventOuterClass.CreatedEvent;
+import com.daml.ledger.api.v1.EventOuterClass.ArchivedEvent;
+import com.daml.ledger.api.v1.EventOuterClass.ExercisedEvent;
+import com.daml.ledger.api.v1.ValueOuterClass;
+import com.daml.ledger.api.v1.ValueOuterClass.Value;
+import com.daml.ledger.api.v1.ValueOuterClass.Record;
+import com.daml.ledger.api.v1.ValueOuterClass.RecordField;
 
-import com.sun.org.apache.xerces.internal.impl.xpath.regex.Match;
 import io.grpc.ManagedChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +98,7 @@ public class TradingPartyProcessor extends EventProcessor {
         public static Asset cashFrom(CreatedEvent event) {
             return new Asset(
                 event.getContractId(),
-                new BigDecimal(getRecordValue(event.getCreateArguments(),"amount").getDecimal()),
+                new BigDecimal(getRecordValue(event.getCreateArguments(),"amount").getNumeric()),
                 getRecordValue(event.getCreateArguments(),"currency").getText(),
                 getRecordValue(event.getCreateArguments(),"owner").getParty(),
                 getRecordValue(event.getCreateArguments(),"issuer").getParty()
@@ -109,7 +108,7 @@ public class TradingPartyProcessor extends EventProcessor {
         public static Asset bondFrom(CreatedEvent event) {
             return  new Asset(
                 event.getContractId(),
-                new BigDecimal(getRecordValue(event.getCreateArguments(),"amount").getDecimal()),
+                new BigDecimal(getRecordValue(event.getCreateArguments(),"amount").getNumeric()),
                 getRecordValue(event.getCreateArguments(),"isin").getText(),
                 getRecordValue(event.getCreateArguments(),"owner").getParty(),
                 getRecordValue(event.getCreateArguments(),"issuer").getParty()            );
@@ -136,7 +135,7 @@ public class TradingPartyProcessor extends EventProcessor {
 
             this.cashLeg = new Asset(
                 null,
-                new BigDecimal(getDvpTermValue(event,"cashAmount").getDecimal()),
+                new BigDecimal(getDvpTermValue(event,"cashAmount").getNumeric()),
                 getDvpTermValue(event,"cashCurrency").getText(),
                 getDvpTermValue(event,"buyer").getParty(),
                 getDvpTermValue(event,"cashIssuer").getParty()
@@ -144,7 +143,7 @@ public class TradingPartyProcessor extends EventProcessor {
 
             this.bondLeg = new Asset(
                 null,
-                new BigDecimal(getDvpTermValue(event,"bondAmount").getDecimal()),
+                new BigDecimal(getDvpTermValue(event,"bondAmount").getNumeric()),
                 getDvpTermValue(event,"bondIsin").getText(),
                 getDvpTermValue(event,"seller").getParty(),
                 getDvpTermValue(event,"bondIssuer").getParty()
@@ -635,7 +634,7 @@ public class TradingPartyProcessor extends EventProcessor {
         assert cashEvent.getTemplateId().getEntityName().equals("Cash.Cash");
         Record cash = cashEvent.getCreateArguments();
         return String.format("%s %s owned by %s, issued by %s, locked=%s",
-            getRecordValue(cash,"amount").getDecimal(),
+            getRecordValue(cash,"amount").getNumeric(),
             getRecordValue(cash,"currency").getText(),
             getRecordValue(cash,"owner").getParty(),
             getRecordValue(cash,"issuer").getParty(),
@@ -647,7 +646,7 @@ public class TradingPartyProcessor extends EventProcessor {
         assert bondEvent.getTemplateId().getEntityName().equals("Bond.Bond");
         Record cash = bondEvent.getCreateArguments();
         return String.format("%s %s, owned by %s, issued by %s",
-            getRecordValue(cash,"amount").getDecimal(),
+            getRecordValue(cash,"amount").getNumeric(),
             getRecordValue(cash,"isin").getText(),
             getRecordValue(cash,"owner").getParty(),
             getRecordValue(cash,"issuer").getParty()
@@ -658,10 +657,10 @@ public class TradingPartyProcessor extends EventProcessor {
         Record dvpTerms = getRecordValue(dvpEvent.getCreateArguments(),"c").getRecord();
         return String.format("%s buys %s %s from %s for %s%s, dvpId=%s, settling at %s",
             getRecordValue(dvpTerms,"buyer").getParty(),
-            getRecordValue(dvpTerms, "bondAmount").getDecimal(),
+            getRecordValue(dvpTerms, "bondAmount").getNumeric(),
             getRecordValue(dvpTerms,"bondIsin").getText(),
             getRecordValue(dvpTerms,"seller").getParty(),
-            getRecordValue(dvpTerms,"cashAmount").getDecimal(),
+            getRecordValue(dvpTerms,"cashAmount").getNumeric(),
             getRecordValue(dvpTerms,"cashCurrency").getText(),
             getRecordValue(dvpTerms,"dvpId").getText(),
             new Timestamp(getRecordValue(dvpTerms,"settleTime").getTimestamp()/1000).toInstant()


### PR DESCRIPTION
There are a few changes in here:

1. Bump the version in the daml.yaml.
2. Bump the version in the pom.xml.
3. Replace the shitty code for finding the main package id via the
   package service by `daml damlc inspect-dar` which is a much more
   sensible solution. This also removes the dependency on
   daml-lf-archive and any DAML-LF parsing.
4. Update all group ids of SDK dependencies from com.digitalasset to
   com.daml. I’ve left the ones for the project intact since I’m lazy
   and there is not much to be gained by changing them.
5. Remove the code for the old time model.
6. Switch from decimal to numeric (on the client side, the models have
   not been modified).
7. Update protobuf-java to match the upgrade on the SDK side.

I’ve run `make start` and the output looks roughly like the
screenshot. I believe the differences can be explained by concurrency
but it could also just be that the screenshot is severly outdated. I
honestly don’t understand the example enough to judge whether there
are other issues.